### PR TITLE
fix: :label: use bigint

### DIFF
--- a/target_redshift/db_sync.py
+++ b/target_redshift/db_sync.py
@@ -70,7 +70,7 @@ def column_type(schema_property, with_length=True):
         column_type = 'character varying'
         varchar_length = LONG_VARCHAR_LENGTH
     elif 'integer' in property_type:
-        column_type = 'numeric'
+        column_type = 'numeric(38,0)'
     elif 'boolean' in property_type:
         column_type = 'boolean'
 


### PR DESCRIPTION
[WIP]
- we are getting "Broken pipe" errors from target-redshift this branch is to test a fix that was implemented it this version of pipelinewise-target-redshift:
https://github.com/transferwise/pipelinewise-target-redshift/compare/master...Reddoorz-Enterprise:pipelinewise-target-redshift:master

changed target datatype to 'numeric(38,0)' from numeric when the source datatype is marked as integer